### PR TITLE
FarmManager: artdaq_partition and MIDAS_SERVER_HOST

### DIFF
--- a/rc/control/component.py
+++ b/rc/control/component.py
@@ -83,7 +83,8 @@ class Component(ContextObject):
         self.__rpc_host  = self.fClient.odb_get("/Mu2e/ActiveRunConfiguration/DAQ/Tfm/RpcHost");
         self.run_params  = None
         self.__dummy_val = 0
-        self.__partition = int(os.environ["ARTDAQ_PARTITION_NUMBER"]);
+        #self.__partition = int(os.environ["ARTDAQ_PARTITION_NUMBER"]);
+        self.__partition = self.fClient.odb_get("/Mu2e/ActiveRunConfiguration/DAQ/PartitionID");
         self.__rpc_port  = 10000+1000*self.__partition;
         self.__messages  = [];
 

--- a/rc/control/farm_manager.py
+++ b/rc/control/farm_manager.py
@@ -494,6 +494,7 @@ class FarmManager(Component):
                     "FarmManager will exit. Look at the messages above, make any necessary "
                     "changes, and restart.\n")
             )
+            TRACE.TRACE(7,f"An exception was thrown when trying to read FarmManager settings;","FarmManager")
             sys.exit(1)
 
         if self.use_messagefacility:
@@ -725,7 +726,7 @@ class FarmManager(Component):
 #---v--------------------------------------------------------------------------
     def read_settings(self):
 
-        self.midas_server_host       = os.path.expandvars(self.fClient.odb_get("/Mu2e/ActiveRunConfiguration/DAQ/MIDAS_SERVER_HOST"));
+        self.midas_server_host       = os.environ["MIDAS_SERVER_HOST"] if "MIDAS_SERVER_HOST" in os.environ else "localhost"
         self.top_output_dir          = os.path.expandvars(self.fClient.odb_get("/Mu2e/OutputDir"));
         self.log_directory           = self.top_output_dir+'/logs';
         self.record_directory        = self.top_output_dir+'/run_records';


### PR DESCRIPTION
**MIDAS_SERVER_HOST**:
 I think it might not be needed to store MIDAS_SERVER_HOST in ODB. Because if we can talk with the ODB, we already know MIDAS_SERVER_HOST? I would propose to use the same scheme that is used for the client. As far as I see it, unfortunately, there doesn't seem to be a straight forward way to get the server_host out of the client. 
 
**ARTDAQ_PARTITION_NUMBER**:
More a question. Why don't we use the "PartitionID" from the ODB for this? 